### PR TITLE
Make @SceneTree path argument optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ DerivedData/
 .netrc
 *~
 build-docs.log
+.nova/

--- a/Sources/SwiftGodotMacroLibrary/SceneTreeMacro.swift
+++ b/Sources/SwiftGodotMacroLibrary/SceneTreeMacro.swift
@@ -1,4 +1,4 @@
-// 
+//
 //  SceneTreeMacro.swift
 //  SwiftGodot
 //
@@ -14,7 +14,6 @@ import SwiftSyntaxMacros
 
 public struct SceneTreeMacro: AccessorMacro {
     enum ProviderDiagnostic: String, DiagnosticMessage {
-        case missingPathArgument
         case invalidDeclaration
         case missingTypeAnnotation
         case nonOptionalTypeAnnotation
@@ -23,8 +22,6 @@ public struct SceneTreeMacro: AccessorMacro {
 
         var message: String {
             switch self {
-            case .missingPathArgument:
-                "Missing argument 'path'"
             case .invalidDeclaration:
                 "SceneTree can only be applied to stored properties"
             case .missingTypeAnnotation:
@@ -47,34 +44,34 @@ public struct SceneTreeMacro: AccessorMacro {
         var fixItID: SwiftDiagnostics.MessageID {
             ProviderDiagnostic.nonOptionalTypeAnnotation.diagnosticID
         }
-
     }
 
     public static func expansion(of node: AttributeSyntax,
                                  providingAccessorsOf declaration: some DeclSyntaxProtocol,
-                                 in context: some MacroExpansionContext) throws -> [AccessorDeclSyntax] {
-        guard let argument = node.arguments?.as(LabeledExprListSyntax.self)?.first?.expression else {
-            let missingArgErr = Diagnostic(node: node.root, message: ProviderDiagnostic.missingPathArgument)
-            context.diagnose(missingArgErr)
-            return [
-                """
-                get { getNodeOrNull(path: NodePath(stringLiteral: "")) as? Node }
-                """
-            ]
-        }
+                                 in context: some MacroExpansionContext) throws -> [AccessorDeclSyntax]
+    {
         guard let varDecl = declaration.as(VariableDeclSyntax.self) else {
             let invalidUsageErr = Diagnostic(node: node.root, message: ProviderDiagnostic.invalidDeclaration)
             context.diagnose(invalidUsageErr)
             return []
         }
+
         guard let nodeType = varDecl.bindings.first?.typeAnnotation?.type else {
             let missingAnnotationErr = Diagnostic(node: node.root, message: ProviderDiagnostic.missingTypeAnnotation)
             context.diagnose(missingAnnotationErr)
             return []
         }
 
+        guard let nodeIdentifier = varDecl.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier else {
+            fatalError("No identifier for this expression could be found.")
+        }
+
+        let preferredIdentifierExpr = node.arguments?.as(LabeledExprListSyntax.self)?.first?.expression.as(StringLiteralExprSyntax.self)
+        let preferredContent = preferredIdentifierExpr?.segments.first?.as(StringSegmentSyntax.self)?.content
+        let preferredIdentifier = preferredContent?.text
+
         let unwrappedType = nodeType.as(OptionalTypeSyntax.self)?.wrappedType ?? nodeType.as(ImplicitlyUnwrappedOptionalTypeSyntax.self)?.wrappedType
-        
+
         guard let unwrappedType else {
             let newOptional = OptionalTypeSyntax(wrappedType: nodeType)
             let addOptionalFix = FixIt(message: MarkOptionalMessage(),
@@ -85,15 +82,15 @@ public struct SceneTreeMacro: AccessorMacro {
             context.diagnose(nonOptional)
             return [
                 """
-                get { getNodeOrNull(path: NodePath(stringLiteral: \(argument))) as? \(nodeType) }
-                """
+                get { getNodeOrNull(path: NodePath(stringLiteral: \"\(raw: preferredIdentifier ?? nodeIdentifier.text)\")) as? \(nodeType) }
+                """,
             ]
         }
 
         return [
             """
-            get { getNodeOrNull(path: NodePath(stringLiteral: \(argument))) as? \(unwrappedType) }
-            """
+            get { getNodeOrNull(path: NodePath(stringLiteral: \"\(raw: preferredIdentifier ?? nodeIdentifier.text)\")) as? \(unwrappedType) }
+            """,
         ]
     }
 }

--- a/Tests/SwiftGodotMacrosTests/SceneTreeMacroTests.swift
+++ b/Tests/SwiftGodotMacrosTests/SceneTreeMacroTests.swift
@@ -5,14 +5,14 @@
 //  Created by Marquis Kurt on 21/6/23.
 //
 
+import SwiftGodotMacroLibrary
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
-import SwiftGodotMacroLibrary
 
 final class SceneTreeMacroTests: XCTestCase {
     let testMacros: [String: Macro.Type] = [
-        "SceneTree": SceneTreeMacro.self
+        "SceneTree": SceneTreeMacro.self,
     ]
 
     func testMacroExpansion() {
@@ -35,7 +35,7 @@ final class SceneTreeMacroTests: XCTestCase {
             macros: testMacros
         )
     }
-    
+
     func testMacroExpansionWithImplicitlyUnwrappedOptional() {
         assertMacroExpansion(
             """
@@ -57,26 +57,22 @@ final class SceneTreeMacroTests: XCTestCase {
         )
     }
 
-    func testMacroMissingPathDiagnostic() {
+    func testMacroExpansionWithDefaultArgument() {
         assertMacroExpansion(
             """
             class MyNode: Node {
-                @SceneTree
-                var character: CharacterBody2D?
+                @SceneTree var character: CharacterBody2D?
             }
             """,
             expandedSource: """
             class MyNode: Node {
                 var character: CharacterBody2D? {
                     get {
-                        getNodeOrNull(path: NodePath(stringLiteral: "")) as? Node
+                        getNodeOrNull(path: NodePath(stringLiteral: "character")) as? CharacterBody2D
                     }
                 }
             }
             """,
-            diagnostics: [
-                .init(message: "Missing argument 'path'", line: 2, column: 5)
-            ],
             macros: testMacros
         )
     }
@@ -103,12 +99,10 @@ final class SceneTreeMacroTests: XCTestCase {
                       line: 2,
                       column: 5,
                       fixIts: [
-                        .init(message: "Mark as Optional")
-                      ])
+                          .init(message: "Mark as Optional"),
+                      ]),
             ],
             macros: testMacros
         )
     }
-    
-    
 }


### PR DESCRIPTION
This PR works towards making @SceneTree closer to @BindNode by making the `path` argument optional.

Currently, `@SceneTree` requires an argument for the path:

```swift
class MyNode: Node2D {
	@SceneTree(path: "SomePath/MyOtherNode")
	var myOtherNode: Node2D?
}
```

There may be cases where providing a path is redundant or not desired, however.

This PR changes the macro to allow not providing a path argument. If the path argument is not provided in the macro, it will use the variable declarations identifier text instead of throwing an error.

Consider the following example:

```swift
class MyNode: Node2D {
	@SceneTree var char2D: CharacterBody2D?
}
```

`@SceneTree` would look for a node named `char2D` exactly. This approach makes no assumptions on spacing or case; it is up to the user to ensure their name matches when using the default argument approach. Otherwise, the path argument can be used to explicitly set formatting or pathing.